### PR TITLE
Performance / system tests

### DIFF
--- a/frinx_python_sdk/setup.py
+++ b/frinx_python_sdk/setup.py
@@ -17,7 +17,7 @@ def __read__(file_name: str) -> AnyStr:
 setup(
     name="frinx-python-sdk",
     package_dir={"": "src"},
-    version="0.0.6",
+    version="0.0.7",
     description="Python SDK for Frinx Machine Workflow Manager",
     data_files=[("logging", ["src/frinx/common/logging/logging-config.json"])],
     author="FRINXio",

--- a/frinx_python_sdk/src/frinx/client/FrinxConductorWrapper.py
+++ b/frinx_python_sdk/src/frinx/client/FrinxConductorWrapper.py
@@ -241,8 +241,8 @@ class FrinxConductorWrapper:
             task["status"] = resp["status"]
             task["outputData"] = resp.get("output", {})
             task["logs"] = resp.get("logs", [])
-            print(resp)
-            print(task)
+            logger.debug("Executing a task %s, response: %s", task["taskId"], resp)
+            logger.debug("Executing a task %s, task body: %s", task["taskId"], task)
             self.taskClient.updateTask(task)
         except Exception:
             self.handleTaskException(task)

--- a/frinx_python_sdk/src/frinx/common/workflow/workflow.py
+++ b/frinx_python_sdk/src/frinx/common/workflow/workflow.py
@@ -97,7 +97,7 @@ class WorkflowImpl(BaseModel, ABC):
 
     # PREDEFINED
     restartable: bool = Field(default=False)
-    output_parameters: WorkflowOutput = Field(default={})
+    output_parameters: dict[str, object] = Field(default={})
     input_parameters: list[WorkflowInputField | str] = Field(default=[])
     tasks: list[WorkflowTaskImpl] = Field(default=[])
     timeout_policy: TimeoutPolicy = Field(default=TimeoutPolicy.ALERT_ONLY)

--- a/frinx_python_sdk/src/frinx/main.py
+++ b/frinx_python_sdk/src/frinx/main.py
@@ -1,13 +1,18 @@
 import logging
+import os
 
 from frinx.common.logging import logging_common
+from frinx.common.logging.logging_common import LoggerConfig
+from frinx.common.logging.logging_common import Root
 
 
 def DebugLocal():
     import os
 
     os.environ["UNICONFIG_URL_BASE"] = "http://localhost/api/uniconfig"
-    os.environ["CONDUCTOR_URL_BASE"] = "http://localhost:8088/proxy/api"
+    os.environ["CONDUCTOR_URL_BASE"] = os.environ.get(
+        "CONDUCTOR_URL_BASE", "http://localhost:8088/proxy/api"
+    )
     os.environ["INVENTORY_URL_BASE"] = "http://localhost/api/inventory"
     os.environ["INFLUXDB_URL_BASE"] = "http://localhost:8086"
     os.environ["RESOURCE_MANAGER_URL_BASE"] = "http://localhost/api/resource"
@@ -16,8 +21,10 @@ def DebugLocal():
 def RegisterTasks(cc):
     from frinx.workers.inventory.inventory_worker import Inventory
     from frinx.workers.monitoring.influxdb_workers import Influx
+    from frinx.workers.test.test_worker import TestWorker
     from frinx.workers.uniconfig.uniconfig_worker import Uniconfig
 
+    TestWorker().register(cc)
     Inventory().register(cc)
     Uniconfig().register(cc)
     Influx().register(cc)
@@ -26,16 +33,22 @@ def RegisterTasks(cc):
 def RegisterWorkflows():
     logging.info("Register workflows")
     from frinx.workflows.inventory.inventory_workflows import InventoryWorkflows
+    from frinx.workflows.misc.test import TestForkWorkflow
+    from frinx.workflows.misc.test import TestWorkflow
     from frinx.workflows.monitoring.influxdb import InfluxWF
     from frinx.workflows.uniconfig.transactions import UniconfigTransactions
 
+    TestWorkflow().register(overwrite=True)
+    TestForkWorkflow().register(overwrite=True)
     UniconfigTransactions().register(overwrite=True)
     InfluxWF().register(overwrite=True)
     InventoryWorkflows().register(overwrite=True)
 
 
 def main():
-    logging_common.configure_logging()
+    logging_common.configure_logging(
+        LoggerConfig(root=Root(level=os.environ.get("LOG_LEVEL", "INFO").upper()))
+    )
 
     DebugLocal()
 
@@ -45,7 +58,7 @@ def main():
 
     cc = FrinxConductorWrapper(
         server_url=conductor_url_base,
-        polling_interval=0.5,
+        polling_interval=0.1,
         max_thread_count=10,
         headers=conductor_headers,
     )

--- a/frinx_python_sdk/src/frinx/workers/test/test_worker.py
+++ b/frinx_python_sdk/src/frinx/workers/test/test_worker.py
@@ -1,0 +1,168 @@
+import copy
+import random
+from typing import Any
+
+from frinx.common.conductor_enums import TaskResultStatus
+from frinx.common.worker.service import ServiceWorkersImpl
+from frinx.common.worker.task import Task
+from frinx.common.worker.task_def import TaskDefinition
+from frinx.common.worker.task_def import TaskInput
+from frinx.common.worker.task_def import TaskOutput
+from frinx.common.worker.task_result import TaskResult
+from frinx.common.worker.worker import WorkerImpl
+
+
+class TestWorker(ServiceWorkersImpl):
+    class Echo(WorkerImpl):
+        class WorkerDefinition(TaskDefinition):
+            name = "TEST_echo"
+            description = "testing purposes: returns input unchanged"
+            labels = ["TEST"]
+            timeout_seconds = 60
+            response_timeout_seconds = 60
+
+        class WorkerInput(TaskInput):
+            input: str
+
+        class WorkerOutput(TaskOutput):
+            output: str
+
+        def execute(self, task: Task, task_result: TaskResult) -> TaskResult:
+            task_result.status = TaskResultStatus.COMPLETED
+            task_result.add_output_data("output", task.input_data.get("input", ""))
+            task_result.logs = "Echo worker invoked successfully"
+            return task_result
+
+    ###############################################################################
+
+    class Sleep(WorkerImpl):
+        DEFAULT_SLEEP = 10
+
+        class WorkerDefinition(TaskDefinition):
+            name = "TEST_sleep"
+            description = "testing purposes: sleep"
+            labels = ["TEST"]
+            timeout_seconds = 600
+            response_timeout_seconds = 600
+
+        class WorkerInput(TaskInput):
+            time: int
+
+        class WorkerOutput(TaskOutput):
+            time: int
+
+        def execute(self, task: Task, task_result: TaskResult) -> TaskResult:
+            sleep = task.input_data.get("time", self.DEFAULT_SLEEP)
+            if sleep < 0 or sleep > 600:
+                task_result.status = TaskResultStatus.FAILED
+                task_result.logs = "Invalid sleep time, must be > 0 and < 600"
+                return task_result
+
+            import time
+
+            task_result.logs = "Sleep worker invoked. Sleeping"
+            time.sleep(sleep)
+            task_result.add_output_data("time", sleep)
+            task_result.status = TaskResultStatus.COMPLETED
+            task_result.logs = "Sleep worker invoked successfully"
+
+            return task_result
+
+    ###############################################################################
+
+    class DynamicForkGenerator(WorkerImpl):
+        class WorkerDefinition(TaskDefinition):
+            name = "TEST_dynamic_fork_generate"
+            description = "testing purposes: generate dynamic fork tasks"
+            labels = ["TEST"]
+            timeout_seconds = 60
+            response_timeout_seconds = 60
+
+        class WorkerInput(TaskInput):
+            wf_count: int
+            wf_name: str
+            wf_inputs: dict
+
+        class WorkerOutput(TaskOutput):
+            dynamic_tasks_i: dict
+            dynamic_tasks: list
+
+        def execute(self, task: Task, task_result: TaskResult) -> TaskResult:
+            wf_count = task.input_data.get("wf_count", 10)
+            wf_name = task.input_data.get("wf_name", "Test_workflow")
+            wf_inputs = task.input_data.get("wf_inputs", {})
+
+            dynamic_tasks = []
+            dynamic_tasks_i = {}
+
+            for t in range(0, wf_count):
+                dynamic_tasks.append(
+                    {
+                        "name": "sub_task",
+                        "taskReferenceName": str(t),
+                        "type": "SUB_WORKFLOW",
+                        "subWorkflowParam": {"name": wf_name, "version": 1},
+                    }
+                )
+                dynamic_tasks_i[str(t)] = wf_inputs
+
+            task_result.add_output_data("dynamic_tasks_i", dynamic_tasks_i)
+            task_result.add_output_data("dynamic_tasks", dynamic_tasks)
+            task_result.status = TaskResultStatus.COMPLETED
+            task_result.logs = "Dynamic fork generator worker invoked successfully"
+
+            return task_result
+
+    class LoremIpsum(WorkerImpl):
+        class WorkerDefinition(TaskDefinition):
+            name = "TEST_lorem_ipsum"
+            description = "testing purposes: text generator"
+            labels = ["TEST"]
+            timeout_seconds = 60
+            response_timeout_seconds = 60
+
+        class WorkerInput(TaskInput):
+            num_paragraphs: int
+            num_sentences: int
+            num_words: int
+
+        class WorkerOutput(TaskOutput):
+            text: str
+            bytes: int
+
+        def execute(self, task: Task, task_result: TaskResult) -> TaskResult:
+            text = generate_text(
+                num_paragraphs=task.input_data.get("num_paragraphs", 3),
+                num_sentences=task.input_data.get("num_sentences", 3),
+                num_words=task.input_data.get("num_words", 3),
+            )
+            task_result.add_output_data("text", text)
+            task_result.add_output_data("bytes", len(text.encode("utf-8")))
+            task_result.status = TaskResultStatus.COMPLETED
+            task_result.logs = "Lorem ipsum worker invoked successfully"
+
+            return task_result
+
+
+WORDS = ["lorem", "ipsum", "dolor", "sit", "amet", "consectetur", "adipiscing", "elit"]
+
+
+def generate_sentence(num_words: int):
+    sentence = []
+    for i in range(num_words):
+        sentence.append(random.choice(WORDS))
+    return " ".join(sentence).capitalize() + "."
+
+
+def generate_paragraph(num_sentences: int, num_words: int):
+    paragraph = []
+    for i in range(num_sentences):
+        paragraph.append(generate_sentence(num_words))
+    return " ".join(paragraph)
+
+
+def generate_text(num_paragraphs: int, num_sentences: int, num_words: int):
+    text = []
+    for i in range(num_paragraphs):
+        text.append(generate_paragraph(num_sentences, num_words))
+    return "\n\n".join(text)

--- a/frinx_python_sdk/src/frinx/workflows/misc/test.py
+++ b/frinx_python_sdk/src/frinx/workflows/misc/test.py
@@ -51,17 +51,17 @@ class TestWorkflow(WorkflowImpl):
         bytes: int
 
     def workflow_builder(self, workflow_inputs: WorkflowInput) -> None:
-        self.tasks.append(
-            SimpleTask(
-                name=TestWorker.LoremIpsum,
-                task_reference_name="generate",
-                input_parameters=SimpleTaskInputParameters(
-                    num_paragraphs=workflow_inputs.num_paragraphs.wf_input,
-                    num_sentences=workflow_inputs.num_sentences.wf_input,
-                    num_words=workflow_inputs.num_words.wf_input,
-                ),
-            )
+        generate_task = SimpleTask(
+            name=TestWorker.LoremIpsum,
+            task_reference_name="generate",
+            input_parameters=SimpleTaskInputParameters(
+                num_paragraphs=workflow_inputs.num_paragraphs.wf_input,
+                num_sentences=workflow_inputs.num_sentences.wf_input,
+                num_words=workflow_inputs.num_words.wf_input,
+            ),
         )
+        self.tasks.append(generate_task)
+
         self.tasks.append(
             SimpleTask(
                 name=TestWorker.Sleep,
@@ -71,16 +71,16 @@ class TestWorkflow(WorkflowImpl):
                 ),
             )
         )
-        self.tasks.append(
-            SimpleTask(
-                name=TestWorker.Echo,
-                task_reference_name="echo",
-                input_parameters=SimpleTaskInputParameters(input="${generate.output.text}"),
-            )
-        )
 
-        self.output_parameters["text"] = "${echo.output.output}"
-        self.output_parameters["bytes"] = "${generate.output.bytes}"
+        echo_task = SimpleTask(
+            name=TestWorker.Echo,
+            task_reference_name="echo",
+            input_parameters=SimpleTaskInputParameters(input=generate_task.output_ref("text")),
+        )
+        self.tasks.append(echo_task)
+
+        self.output_parameters["text"] = echo_task.output_ref("output")
+        self.output_parameters["bytes"] = generate_task.output_ref("bytes")
 
 
 class TestForkWorkflow(WorkflowImpl):

--- a/frinx_python_sdk/src/frinx/workflows/misc/test.py
+++ b/frinx_python_sdk/src/frinx/workflows/misc/test.py
@@ -1,0 +1,135 @@
+from frinx.common.workflow.service import ServiceWorkflowsImpl
+from frinx.common.workflow.task import DynamicForkTask
+from frinx.common.workflow.task import DynamicForkTaskInputParameters
+from frinx.common.workflow.task import JoinTask
+from frinx.common.workflow.task import SimpleTask
+from frinx.common.workflow.task import SimpleTaskInputParameters
+from frinx.common.workflow.workflow import FrontendWFInputFieldType
+from frinx.common.workflow.workflow import WorkflowImpl
+from frinx.common.workflow.workflow import WorkflowInputField
+from frinx.workers.test.test_worker import TestWorker
+
+
+class TestWorkflow(WorkflowImpl):
+    name = "Test_workflow"
+    version = 1
+    description = "Test workflow built from test workers"
+    labels = ["TEST"]
+    timeout_seconds = 60 * 5
+
+    class WorkflowInput(WorkflowImpl.WorkflowInput):
+        num_paragraphs = WorkflowInputField(
+            name="num_paragraphs",
+            frontend_default_value=10,
+            description="Paragraphs to generate",
+            type=FrontendWFInputFieldType.INT,
+        )
+
+        num_sentences = WorkflowInputField(
+            name="num_sentences",
+            frontend_default_value=10,
+            description="Sentences to generate per paragraph",
+            type=FrontendWFInputFieldType.INT,
+        )
+
+        num_words = WorkflowInputField(
+            name="num_words",
+            frontend_default_value=10,
+            description="Words to generate per sentence",
+            type=FrontendWFInputFieldType.INT,
+        )
+
+        sleep_time = WorkflowInputField(
+            name="sleep_time",
+            frontend_default_value="10",
+            description="How many seconds to sleep during the workflow",
+            type=FrontendWFInputFieldType.INT,
+        )
+
+    class WorkflowOutput(WorkflowImpl.WorkflowOutput):
+        text: str
+        bytes: int
+
+    def workflow_builder(self, workflow_inputs: WorkflowInput) -> None:
+        self.tasks.append(
+            SimpleTask(
+                name=TestWorker.LoremIpsum,
+                task_reference_name="generate",
+                input_parameters=SimpleTaskInputParameters(
+                    num_paragraphs=workflow_inputs.num_paragraphs.wf_input,
+                    num_sentences=workflow_inputs.num_sentences.wf_input,
+                    num_words=workflow_inputs.num_words.wf_input,
+                ),
+            )
+        )
+        self.tasks.append(
+            SimpleTask(
+                name=TestWorker.Sleep,
+                task_reference_name="sleep",
+                input_parameters=SimpleTaskInputParameters(
+                    time=workflow_inputs.sleep_time.wf_input
+                ),
+            )
+        )
+        self.tasks.append(
+            SimpleTask(
+                name=TestWorker.Echo,
+                task_reference_name="echo",
+                input_parameters=SimpleTaskInputParameters(input="${generate.output.text}"),
+            )
+        )
+
+        self.output_parameters["text"] = "${echo.output.output}"
+        self.output_parameters["bytes"] = "${generate.output.bytes}"
+
+
+class TestForkWorkflow(WorkflowImpl):
+    name = "Test_fork_workflow"
+    version = 1
+    description = "Test workflows executed in a parallel, dynamic fork"
+    labels = ["TEST"]
+    timeout_seconds = 60 * 5
+
+    class WorkflowInput(TestWorkflow.WorkflowInput):
+        fork_count = WorkflowInputField(
+            name="fork_count",
+            frontend_default_value=10,
+            description="How many forks to execute in parallel",
+            type=FrontendWFInputFieldType.INT,
+        )
+
+    class WorkflowOutput(WorkflowImpl.WorkflowOutput):
+        pass
+
+    def workflow_builder(self, workflow_inputs: WorkflowInput) -> None:
+        self.tasks.append(
+            SimpleTask(
+                name=TestWorker.DynamicForkGenerator,
+                task_reference_name="fork_generator",
+                input_parameters=SimpleTaskInputParameters(
+                    wf_count=workflow_inputs.fork_count.wf_input,
+                    wf_name="Test_workflow",
+                    wf_inputs={
+                        "num_words": workflow_inputs.num_words.wf_input,
+                        "num_sentences": workflow_inputs.num_sentences.wf_input,
+                        "num_paragraphs": workflow_inputs.num_paragraphs.wf_input,
+                        "sleep_time": workflow_inputs.sleep_time.wf_input,
+                    },
+                ),
+            )
+        )
+
+        self.tasks.append(
+            DynamicForkTask(
+                name="dyn_fork",
+                task_reference_name="dyn_fork",
+                dynamicForkTasksParam="dynamic_tasks",
+                dynamic_fork_tasks_input_param_name="dynamic_tasks_input",
+                input_parameters=DynamicForkTaskInputParameters(
+                    dynamic_tasks="${fork_generator.output.dynamic_tasks}",
+                    dynamic_tasks_input="${fork_generator.output.dynamic_tasks_i}",
+                ),
+            )
+        )
+
+        self.tasks.append(JoinTask(name="dyn_fork_join", task_reference_name="dyn_fork_join"))

--- a/system_tests/pytest.ini
+++ b/system_tests/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+
+log_cli = 1
+log_cli_level = INFO
+log_cli_format = %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+log_cli_date_format=%Y-%m-%d %H:%M:%S
+
+#log_file = log.log_file
+#log_file_level = INFO
+#log_file_format= %(asctime)s [%(levelname)8s] %(message)s (%(filename)s:%(lineno)s)
+#log_file_date_format=%Y-%m-%d %H:%M:%S

--- a/system_tests/requirements.txt
+++ b/system_tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+pytest-asyncio
+requests

--- a/system_tests/tests/frinx/test_performance.py
+++ b/system_tests/tests/frinx/test_performance.py
@@ -1,0 +1,270 @@
+import asyncio
+import json
+import logging
+import os
+import statistics
+import time as sleep_time
+from datetime import timedelta
+from timeit import default_timer as timer
+
+import aiohttp
+import pytest
+
+LOGGER = logging.getLogger(__name__)
+CONDUCTOR_URL = os.environ.get("CONDUCTOR_URL", "http://localhost:8080/api/")
+
+CONDUCTOR_WF_EXEC_RQ = {
+    "name": "Test_workflow",
+    "input": {"num_paragraphs": 10, "num_sentences": 10, "num_words": 10, "sleep_time": 0},
+}
+CONDUCTOR_WF_EXEC_RQ_EXTERNAL_STORAGE = {
+    "name": "Test_workflow",
+    # ~ 700kB
+    "input": {"num_paragraphs": 100, "num_sentences": 100, "num_words": 10, "sleep_time": 0},
+}
+CONDUCTOR_WF_EXEC_RQ_FORK = {
+    "name": "Test_fork_workflow",
+    "input": {
+        "fork_count": 10,
+        "num_paragraphs": 10,
+        "num_sentences": 10,
+        "num_words": 10,
+        "sleep_time": 0,
+    },
+}
+
+CONDUCTOR_HEADERS = {"Content-Type": "application/json", "Accept": "application/json"}
+
+
+async def exec_wf(session, wf_rq: dict = CONDUCTOR_WF_EXEC_RQ, index=0) -> str:
+    url = CONDUCTOR_URL + "workflow"
+    LOGGER.debug("Executing workflow %s", index)
+    async with session.post(url, data=json.dumps(wf_rq), headers=CONDUCTOR_HEADERS) as r_future:
+        response = await r_future.read()
+        r_future.raise_for_status()
+        return response.decode("utf-8")
+
+
+async def get_running_wf_ids(session, wf_type="Test_workflow") -> bytes:
+    url = CONDUCTOR_URL + "workflow/running/" + wf_type
+    async with session.get(url, headers=CONDUCTOR_HEADERS) as response:
+        return await response.read()
+
+
+async def get_wf_execution(session, wf_id) -> dict:
+    url = CONDUCTOR_URL + "workflow/" + wf_id + "?includeTasks=true"
+    async with session.get(url, headers=CONDUCTOR_HEADERS) as r_future:
+        response = await r_future.read()
+        r_future.raise_for_status()
+        return json.loads(response)
+
+
+async def get_external_payload(session, external_id):
+    url = CONDUCTOR_URL + "workflow/externalstoragelocation"
+    params = {"path": external_id, "operation": "READ", "payloadType": "WORKFLOW_OUTPUT"}
+    async with session.get(url, headers=CONDUCTOR_HEADERS, params=params) as r_future:
+        # intermediate response
+        raw = await r_future.read()
+        parsed = json.loads(raw.decode("utf-8"))
+        content_uri = parsed["uri"]
+        async with session.get(
+            content_uri, headers=CONDUCTOR_HEADERS, params=params
+        ) as r_future_inner:
+            # actual content response
+            raw_inner = await r_future_inner.read()
+            return json.loads(raw_inner.decode("utf-8"))
+
+
+async def get_wf_output(executed_ids, session):
+    wf_execution = await get_wf_execution(session, executed_ids[-1])
+    if "externalOutputPayloadStoragePath" in wf_execution:
+        return await get_external_payload(session, wf_execution["externalOutputPayloadStoragePath"])
+    return wf_execution.get("output", {})
+
+
+async def collect_stats(session, wf_ids: tuple[str]) -> dict:
+    durations = []
+    failed = 0
+    for wf_id in wf_ids:
+        wf = await get_wf_execution(session, wf_id)
+        wf_duration_ms = wf["endTime"] - wf["startTime"]
+        wf_status = wf["status"]
+        match wf_status:
+            case "COMPLETED":
+                pass
+            case "FAILED":
+                failed = failed + 1
+            case _:
+                LOGGER.warning("Unexpected status for workflow %s: %s", wf_id, wf_status)
+
+        durations.append(wf_duration_ms)
+
+    return {
+        "median_duration_seconds": timedelta(milliseconds=statistics.median(durations)).seconds,
+        "average_duration_seconds": timedelta(milliseconds=statistics.mean(durations)).seconds,
+        "duration_quantiles": [round(q, 1) for q in statistics.quantiles(durations, n=10)],
+        "failed_workflows": failed,
+    }
+
+
+@pytest.mark.asyncio
+async def test_performance_simple_wf():
+    EXECUTIONS = 1000
+    SLEEP = 4
+    SAMPLING_RATE = 10
+
+    async with aiohttp.ClientSession() as session:
+        start = timer()
+        LOGGER.info("Executing %s workflows", EXECUTIONS)
+
+        wf_exec_futures = [
+            asyncio.ensure_future(exec_wf(session, CONDUCTOR_WF_EXEC_RQ, i))
+            for i in range(EXECUTIONS)
+        ]
+        LOGGER.debug("Waiting for %s workflow executions to return response", EXECUTIONS)
+        executed_ids = await asyncio.gather(*wf_exec_futures)
+        LOGGER.debug("All workflow executions received")
+
+        end = timer()
+        logging.info(
+            "Took %s to submit all %s executions", timedelta(seconds=end - start), EXECUTIONS
+        )
+
+        while True:
+            running_wfs = await get_running_wf_ids(session)
+            running_wfs_ids, running_wfs_len = parse_running_wf_ids(running_wfs)
+
+            if running_wfs_len == 0:
+                break
+
+            logging.info("Still running: %s workflows", running_wfs_len)
+            sleep_time.sleep(SLEEP)
+
+        end = timer()
+
+        stats = await collect_stats(session, executed_ids[0::SAMPLING_RATE])
+        stats.update({"wfs_per_minute": (EXECUTIONS / timedelta(seconds=end - start).seconds) * 60})
+        LOGGER.info("Execution stats: %s", stats)
+
+        last_wf_output = await get_wf_output(executed_ids, session)
+        LOGGER.debug("Last workflow output: %s", last_wf_output)
+        LOGGER.info("Workflow payload size: %s bytes", last_wf_output.get("bytes", -1))
+
+        assert stats["failed_workflows"] == 0
+
+        return stats
+
+
+@pytest.mark.asyncio
+async def test_performance_simple_wf_long():
+    BATCHES = 10
+
+    all_stats = []
+    for i in range(0, BATCHES):
+        LOGGER.info("Executing batch: %s", i)
+        stats = await test_performance_simple_wf()
+        all_stats.append(stats)
+
+    for stat in all_stats:
+        LOGGER.info("Stats: %s", stat)
+
+
+@pytest.mark.asyncio
+async def test_performance_fork():
+    EXECUTIONS = 10
+    FORKS = 100
+    SLEEP = 4
+    SAMPLING_RATE = 1
+
+    async with aiohttp.ClientSession() as session:
+        start = timer()
+        LOGGER.info("Executing %s workflows * %s child/forked workflows", EXECUTIONS, FORKS)
+
+        CONDUCTOR_WF_EXEC_RQ_FORK["input"]["fork_count"] = FORKS
+        wf_exec_futures = [
+            asyncio.ensure_future(exec_wf(session, CONDUCTOR_WF_EXEC_RQ_FORK, i))
+            for i in range(EXECUTIONS)
+        ]
+        executed_ids = await asyncio.gather(*wf_exec_futures)
+
+        while True:
+            running_wfs = await get_running_wf_ids(session)
+            _, running_wfs_len = parse_running_wf_ids(running_wfs)
+            running_wfs_main = await get_running_wf_ids(session, "Test_fork_workflow")
+            _, running_wfs_len_main = parse_running_wf_ids(running_wfs_main)
+
+            running_wfs_len = running_wfs_len + running_wfs_len_main
+
+            if running_wfs_len == 0:
+                break
+
+            logging.info("Still running: %s workflows", running_wfs_len)
+            sleep_time.sleep(SLEEP)
+
+        end = timer()
+
+        stats = await collect_stats(session, executed_ids[0::SAMPLING_RATE])
+        stats.update(
+            {"wfs_per_minute": (FORKS * EXECUTIONS / timedelta(seconds=end - start).seconds) * 60}
+        )
+        LOGGER.info("Execution stats: %s", stats)
+
+        last_wf_output = await get_wf_output(executed_ids, session)
+        LOGGER.debug("Last workflow output: %s", last_wf_output)
+        LOGGER.info("Workflow payload size: %s bytes", last_wf_output.get("bytes", -1))
+
+        assert stats["failed_workflows"] == 0
+
+
+@pytest.mark.asyncio
+async def test_performance_simple_wf_external_storage():
+    EXECUTIONS = 200
+    SLEEP = 4
+    SAMPLING_RATE = 10
+
+    async with aiohttp.ClientSession() as session:
+        start = timer()
+        LOGGER.info("Executing %s workflows", EXECUTIONS)
+
+        wf_exec_futures = [
+            asyncio.ensure_future(exec_wf(session, CONDUCTOR_WF_EXEC_RQ_EXTERNAL_STORAGE, i))
+            for i in range(EXECUTIONS)
+        ]
+        executed_ids = await asyncio.gather(*wf_exec_futures)
+
+        end = timer()
+        logging.info("Executed %s workflows", len(executed_ids))
+        logging.info(
+            "Took %s to submit all %s executions", timedelta(seconds=end - start), EXECUTIONS
+        )
+
+        while True:
+            running_wfs = await get_running_wf_ids(session)
+            running_wfs_ids, running_wfs_len = parse_running_wf_ids(running_wfs)
+
+            if running_wfs_len == 0:
+                break
+
+            logging.info("Still running: %s workflows", running_wfs_len)
+            sleep_time.sleep(SLEEP)
+
+        end = timer()
+
+        stats = await collect_stats(session, executed_ids[0::SAMPLING_RATE])
+        stats.update({"wfs_per_minute": (EXECUTIONS / timedelta(seconds=end - start).seconds) * 60})
+        LOGGER.info("Execution stats: %s", stats)
+
+        last_wf_output = await get_wf_output(executed_ids, session)
+        LOGGER.debug("Last workflow output: %s", last_wf_output)
+        LOGGER.info("Workflow payload size: %s bytes", last_wf_output.get("bytes", -1))
+
+        assert stats["failed_workflows"] == 0
+
+
+def parse_running_wf_ids(running_wfs: bytes):
+    running_wfs_no_brackets = running_wfs.decode("utf-8")[1:-1]
+    if not running_wfs_no_brackets:
+        return [], 0
+    running_wfs_ids = running_wfs_no_brackets.split(",")
+    running_wfs_len = len(running_wfs_ids)
+    return running_wfs_ids, running_wfs_len


### PR DESCRIPTION
Starting with 4 performance tests

Run by:
- Run psql container
- Run conductor
- Run workers by e.g. CONDUCTOR_URL_BASE=http://localhost:8080/api LOG_LEVEL=INFO PYTHONPATH=/home/maros/Projects/fm-base-workers/frinx_python_sdk/src /home/maros/Projects/fm-base-workers/venv/bin/python  /home/maros/Projects/fm-base-workers/frinx_python_sdk/src/frinx/main.py

The expectations are:
- These test workers and workflows will be a standard part of the package
- They will be executed as part of the system test suite regularly

Some other changes:
- Increase polling interval (conductor now does caching on the queue/all)
- Remove some print() functions from conductor client code in favor of LOGGING (huge inputs/outputs were always printed to stdout)

#### Checklist
- [x] Add description to the PR
- [x] Bump version in setup.py for dedicated python package
