### PR TITLE
Make params parameter more specific in execute_and_read_rpc_cli

### DIFF
--- a/frinx_python_sdk/setup.py
+++ b/frinx_python_sdk/setup.py
@@ -17,7 +17,7 @@ def __read__(file_name: str) -> AnyStr:
 setup(
     name="frinx-python-sdk",
     package_dir={"": "src"},
-    version="0.0.8",
+    version="0.0.9",
     description="Python SDK for Frinx Machine Workflow Manager",
     data_files=[("logging", ["src/frinx/common/logging/logging-config.json"])],
     author="FRINXio",

--- a/frinx_python_sdk/src/frinx/services/uniconfig/cli_worker.py
+++ b/frinx_python_sdk/src/frinx/services/uniconfig/cli_worker.py
@@ -3,6 +3,7 @@ import json
 import logging
 from string import Template
 from typing import Any
+from typing import Optional
 
 from aiohttp import ClientSession
 from frinx.common.frinx_rest import uniconfig_headers
@@ -192,13 +193,11 @@ def execute_unmount_cli(device_id: str) -> UniconfigOutput:
 def execute_and_read_rpc_cli(
     device_id: str,
     template: str,
-    params: dict[Any, Any],
+    params: Optional[dict[Any, Any]],
     uniconfig_context: UniconfigContext,
     output_timer: str,
 ) -> UniconfigOutput:
     params = params if params else {}
-    # params = params if isinstance(params, dict) else eval(params) ???
-    params = params if isinstance(params, dict) else eval(str(params))
 
     uniconfig_cookies = uniconfig_utils.extract_uniconfig_cookies(uniconfig_context)
 


### PR DESCRIPTION
The _params_ parameter is optional, because we check in the implementation of the function if the variable is set. 

Also the line below is security vulnerability as you can pass into the eval whatever you want, without any validation.
```python
    params = params if isinstance(params, dict) else eval(str(params))
```